### PR TITLE
Use grep crates: read file via searcher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,6 @@ impl Matcher for TreeSitterMatcher<'_> {
         let match_ = matches_info.matches.remove(0);
         Ok(Some(adjust_match(
             match_,
-            at,
             haystack.len(),
             matches_info.text_len,
         )))
@@ -145,13 +144,8 @@ struct PopulatedMatchesInfo {
     text_len: usize,
 }
 
-fn adjust_match(
-    match_: Match,
-    at: usize,
-    haystack_len: usize,
-    total_file_text_len: usize,
-) -> Match {
-    let offset_in_file = total_file_text_len - haystack_len + at;
+fn adjust_match(match_: Match, haystack_len: usize, total_file_text_len: usize) -> Match {
+    let offset_in_file = total_file_text_len - haystack_len;
     Match::new(
         match_.start() - offset_in_file,
         match_.end() - offset_in_file,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,20 +3,21 @@ use grep::matcher::Match;
 use grep::matcher::Matcher;
 use grep::matcher::NoCaptures;
 use grep::matcher::NoError;
-use grep::searcher::Searcher;
+use grep::searcher::SearcherBuilder;
 use ignore::{types::TypesBuilder, DirEntry, WalkBuilder};
 use rayon::prelude::*;
+use std::cell::RefCell;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use tree_sitter::{Language, Query};
 
 mod language;
 mod macros;
 mod treesitter;
 
 use language::{SupportedLanguage, SupportedLanguageName};
-use treesitter::{get_query, get_results};
+use treesitter::{get_matches, get_query};
 
 #[derive(Parser)]
 pub struct Args {
@@ -55,11 +56,12 @@ pub fn run(args: Args) {
         .for_each(|project_file_dir_entry| {
             let mut printer = grep::printer::Standard::new_no_color(io::stdout());
             let path = project_file_dir_entry.path();
-            let matches = get_results(&query, path, capture_index, language);
 
-            let matcher = TreeSitterMatcher::new(matches);
+            let matcher = TreeSitterMatcher::new(&query, capture_index, language);
 
-            Searcher::new()
+            SearcherBuilder::new()
+                .multi_line(true)
+                .build()
                 .search_path(&matcher, path, printer.sink_with_path(&matcher, path))
                 .unwrap();
         })
@@ -80,37 +82,78 @@ fn enumerate_project_files(language: &dyn SupportedLanguage) -> Vec<DirEntry> {
         .filter(|entry| entry.metadata().unwrap().is_file())
         .collect()
 }
+
 #[derive(Debug)]
-struct TreeSitterMatcher {
-    matches: Mutex<Vec<Match>>,
+struct TreeSitterMatcher<'query> {
+    query: &'query Query,
+    capture_index: u32,
+    language: Language,
+    matches_info: RefCell<Option<PopulatedMatchesInfo>>,
 }
 
-impl TreeSitterMatcher {
-    fn new(mut matches: Vec<Match>) -> Self {
-        matches.sort_by_key(|m| m.start());
-
+impl<'query> TreeSitterMatcher<'query> {
+    fn new(query: &'query Query, capture_index: u32, language: Language) -> Self {
         Self {
-            matches: Mutex::new(matches),
+            query,
+            capture_index,
+            language,
+            matches_info: Default::default(),
         }
     }
 }
 
-impl Matcher for TreeSitterMatcher {
+impl Matcher for TreeSitterMatcher<'_> {
     type Captures = NoCaptures;
 
     type Error = NoError;
 
-    fn find_at(&self, _haystack: &[u8], at: usize) -> Result<Option<Match>, Self::Error> {
-        let _match = self
-            .matches
-            .lock()
-            .unwrap()
-            .pop()
-            .map(|m| Match::new(m.start() - at, m.end() - at));
-        Ok(_match)
+    fn find_at(&self, haystack: &[u8], at: usize) -> Result<Option<Match>, Self::Error> {
+        let mut matches_info = self.matches_info.borrow_mut();
+        if let Some(matches_info) = matches_info.as_ref() {
+            assert!(
+                haystack.len() < matches_info.text_len,
+                "Expected to get passed subset of file text on subsequent invocations"
+            );
+        }
+        let matches_info = matches_info.get_or_insert_with(|| {
+            assert!(at == 0);
+            PopulatedMatchesInfo {
+                matches: get_matches(self.query, self.capture_index, haystack, self.language),
+                text_len: haystack.len(),
+            }
+        });
+        if matches_info.matches.is_empty() {
+            return Ok(None);
+        }
+        let match_ = matches_info.matches.remove(0);
+        Ok(Some(adjust_match(
+            match_,
+            at,
+            haystack.len(),
+            matches_info.text_len,
+        )))
     }
 
     fn new_captures(&self) -> Result<Self::Captures, Self::Error> {
         Ok(NoCaptures::new())
     }
+}
+
+#[derive(Debug)]
+struct PopulatedMatchesInfo {
+    matches: Vec<Match>,
+    text_len: usize,
+}
+
+fn adjust_match(
+    match_: Match,
+    at: usize,
+    haystack_len: usize,
+    total_file_text_len: usize,
+) -> Match {
+    let offset_in_file = total_file_text_len - haystack_len + at;
+    Match::new(
+        match_.start() - offset_in_file,
+        match_.end() - offset_in_file,
+    )
 }

--- a/src/treesitter/mod.rs
+++ b/src/treesitter/mod.rs
@@ -1,6 +1,4 @@
 use grep::matcher::Match;
-use std::fs;
-use std::path::Path;
 use tree_sitter::{Language, Parser, Query, QueryCursor};
 
 pub fn get_parser(language: Language) -> Parser {
@@ -15,18 +13,18 @@ pub fn get_query(source: &str, language: Language) -> Query {
     Query::new(language, source).unwrap()
 }
 
-pub fn get_results(
+pub fn get_matches(
     query: &Query,
-    file_path: impl AsRef<Path>,
     capture_index: u32,
+    file_text_as_bytes: &[u8],
     language: Language,
 ) -> Vec<Match> {
     let mut query_cursor = QueryCursor::new();
-    let file_path = file_path.as_ref();
-    let file_text = fs::read_to_string(file_path).unwrap();
-    let tree = get_parser(language).parse(&file_text, None).unwrap();
+    let file_text =
+        std::str::from_utf8(file_text_as_bytes).expect("Expected file text to be valid UTF-8");
+    let tree = get_parser(language).parse(file_text, None).unwrap();
     query_cursor
-        .matches(query, tree.root_node(), file_text.as_bytes())
+        .matches(query, tree.root_node(), file_text_as_bytes)
         .flat_map(|match_| {
             match_
                 .nodes_for_capture_index(capture_index)


### PR DESCRIPTION
In this PR:
- Looks like I got this working and made it not independently read the file text to drive running the tree-sitter query (per file) (instead using the file text as supplied by the `Searcher` which is presumably doing something more efficient in terms of file I/O)

To test:
See if you now see the expected `grep`-style output + correct results. Definitely try it against a query that returns more than one result for some files, eg I was using this query (for all reference-type'd function parameters):
```
(parameter
  type: (reference_type) @type
)
```

Based on `grep-crates`